### PR TITLE
Add Dockerfile for main app and update docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:20-alpine
+
+# User setup and copy application files
+ENV USER=banki
+ENV UID=1001
+
+RUN adduser \
+  --disabled-password \
+  --gecos "" \
+  --home "$(pwd)" \
+  --uid "$UID" \
+  "$USER"
+
+# Copy app files
+WORKDIR /home/banki
+COPY --chown=banki:banki . .
+RUN chmod +x docker/*.sh
+
+# Install project dependencies
+RUN npm install
+
+# ENTRYPOINT ["docker/entrypoint.sh"]
+CMD ["docker/start.sh"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,18 @@
 version: "3.8"
 services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: banki-brunch:development
+    container_name: banki-brunch-app
+    command: /app/docker/start.sh
+    ports:
+      - 8080:8080
+    volumes:
+      - .:/app
   mongo:
+    image: mongo
     ports:
       - "27017:27017"
     container_name: banki-brunch-mongo
@@ -8,4 +20,3 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=banki
       - MONGO_INITDB_ROOT_PASSWORD=brunch
-    image: mongo

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npm run dev

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 8080 --host",
     "build": "vite build",
     "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "db:up": "docker compose up -d",
-    "db:stop": "docker compose stop",
+    "db:up": "docker compose up -d mongo",
+    "db:stop": "docker compose stop mongo",
     "start": "nodemon app.js"
   },
   "dependencies": {


### PR DESCRIPTION
This PR addresses issue #13 by setting up a docker container for the main application.
- Add a `Dockerfile` for the main application and sets up an `app` service for it in `docker-compose.yml`
- Update `db:up` and `db:stop` commands in `package.json` to target the `db` service in `docker-compose.yml`
- **NOTE**: the default port for the main app was configured to 8080 instead of Vite's default of 5173 since the current configuration requires a hardcoded PORT number.

Run the command `docker compose up` or `docker-compose up` (depending on your Docker installation) to spin up the main app and the MongoDB instance.

You can also use `docker compose up -d` to run them in the background.

Run `docker compose down` in the same directory to shutdown all the app's containers or use <kbd>Ctrl + C</kbd> if the you didn't use the `-d` flag.